### PR TITLE
Fix pointer up events not properly releasing server pen

### DIFF
--- a/client/lib/vtablet.dart
+++ b/client/lib/vtablet.dart
@@ -103,7 +103,7 @@ class VTabletPage extends StatelessWidget {
 
     int pointerX = screenToDigi(rawX, offsetX, ariaWidth, boxWidth);
     int pointerY = screenToDigi(rawY, offsetY, ariaHeight, boxHeight);
-    int pressure = (8192 * rawPressure).toInt();
+    int pressure = event.down ? (8192 * rawPressure).toInt() : 0;
 
     double tiltX = rawTilt * math.cos(rawOrientation) * 90;
     double tiltY = rawTilt * math.sin(rawOrientation) * 90;


### PR DESCRIPTION
Tested on an Android phone. Previously, the server/windows ink pen would remain in a stuck state due to the pressure being `8192`. This PR forces the pressure to `0` if the client pointer isn't [down](https://api.flutter.dev/flutter/gestures/PointerEvent/down.html).